### PR TITLE
Remove extraneous `key`s

### DIFF
--- a/index.es6
+++ b/index.es6
@@ -14,8 +14,14 @@ export default class List extends React.Component {
 
   renderChildren() {
     function createListItem(child) {
+      const key = child.key;
+      const childWithoutKey = React.cloneElement(
+        { ...child, key: null },
+        child.props,
+        child.props.children
+      );
       return (
-        <li className="list__item" key={child.key}>{child}</li>
+        <li className="list__item" key={key}>{childWithoutKey}</li>
       );
     }
     let children = this.props.children;

--- a/test/index.es6
+++ b/test/index.es6
@@ -68,4 +68,15 @@ describe('List', () => {
       liClassNames.length.should.equal(1);
     });
   });
+
+  it('each child item should lose their key, as it\'s only useful on the <li>', () => {
+    const listInstance = new List({}, {});
+    listInstance.props.children = (<a key="1">foo</a>);
+    const rendered = listInstance.render();
+    const liTag = rendered.props.children[0];
+    const aTag = liTag.props.children;
+    (aTag.key == null).should.equal(true);
+    liTag.key.should.equal('1');
+    aTag.props.children.should.equal('foo')
+  });
 });

--- a/test/index.es6
+++ b/test/index.es6
@@ -1,5 +1,7 @@
 import List from '../index.es6';
 import React from 'react/addons';
+import chai from 'chai';
+const should = chai.should;
 
 const TestUtils = React.addons.TestUtils;
 describe('List', () => {
@@ -75,7 +77,7 @@ describe('List', () => {
     const rendered = listInstance.render();
     const liTag = rendered.props.children[0];
     const aTag = liTag.props.children;
-    (aTag.key == null).should.equal(true);
+    should(aTag.key).equal(undefined);
     liTag.key.should.equal('1');
     aTag.props.children.should.equal('foo')
   });


### PR DESCRIPTION
Remove extraneous child keys.

The children here don't need a key, just the actual `<li>` elements.